### PR TITLE
Fetch pullRequests if not available

### DIFF
--- a/memconfig.lock
+++ b/memconfig.lock
@@ -1,13 +1,5 @@
 {
   "types": {
-    "process": {
-      "gref_hash": "c7a6cc4739f2a6aa697342cf67d4924b8be757dbc2bd9eae395bc939f10d54ea",
-      "type": "sys-process:Root"
-    },
-    "github": {
-      "gref_hash": "e6e65bff3bc6bf18cb624db3dc3875132855784b407ad6877c3f2b19e56a428a",
-      "type": "github:Root"
-    },
     "http": {
       "gref_hash": "5cfa57fe83d1201eb831cc168a5dbe9decaa6010603df244ca6855f2fe61440c",
       "type": "http:Root"
@@ -16,99 +8,12 @@
       "gref_hash": "a15ba8f4b17255a57b21182e20ff7b3c0e01c14a6b55a9eecb95f82304bf1d74",
       "type": "github:Repository"
     },
-    "clock": {
-      "gref_hash": "da9d1c247b69702ed49d157f0d697d132f917d00f407438e43c7e438c837c024",
-      "type": "sys-clock:Root"
+    "github": {
+      "gref_hash": "e6e65bff3bc6bf18cb624db3dc3875132855784b407ad6877c3f2b19e56a428a",
+      "type": "github:Root"
     }
   },
   "imports": [
-    {
-      "name": "sys-clock",
-      "schema": {
-        "types": [
-          {
-            "name": "Root",
-            "description": "",
-            "actions": [
-              {
-                "name": "sleep",
-                "description": "",
-                "type": "Void",
-                "params": [
-                  {
-                    "name": "key",
-                    "type": "String"
-                  },
-                  {
-                    "name": "seconds",
-                    "type": "Float"
-                  }
-                ],
-                "hints": {}
-              }
-            ],
-            "fields": [],
-            "events": [
-              {
-                "name": "timer",
-                "description": "",
-                "type": "TimerEvent",
-                "params": [
-                  {
-                    "name": "key",
-                    "type": "String"
-                  },
-                  {
-                    "name": "spec",
-                    "type": "String"
-                  },
-                  {
-                    "name": "maxCount",
-                    "type": "Int"
-                  }
-                ],
-                "hints": {}
-              },
-              {
-                "name": "timerAt",
-                "description": "",
-                "type": "TimerEvent",
-                "params": [
-                  {
-                    "name": "key",
-                    "type": "String"
-                  },
-                  {
-                    "name": "seconds",
-                    "type": "String"
-                  }
-                ],
-                "hints": {}
-              }
-            ]
-          },
-          {
-            "name": "TimerEvent",
-            "description": "",
-            "actions": [],
-            "fields": [
-              {
-                "name": "id",
-                "description": "",
-                "type": "String",
-                "params": [],
-                "hints": {}
-              }
-            ],
-            "events": []
-          }
-        ],
-        "imports": []
-      },
-      "source": {
-        "Program": "tbd"
-      }
-    },
     {
       "name": "github",
       "schema": {
@@ -1779,6 +1684,13 @@
                 "hints": {}
               },
               {
+                "name": "merge",
+                "description": "",
+                "type": "Void",
+                "params": [],
+                "hints": {}
+              },
+              {
                 "name": "createComment",
                 "description": "",
                 "type": "Void",
@@ -2298,93 +2210,6 @@
         ],
         "imports": [
           {
-            "name": "sys-clock",
-            "schema": {
-              "types": [
-                {
-                  "name": "Root",
-                  "description": "",
-                  "actions": [
-                    {
-                      "name": "sleep",
-                      "description": "",
-                      "type": "Void",
-                      "params": [
-                        {
-                          "name": "key",
-                          "type": "String"
-                        },
-                        {
-                          "name": "seconds",
-                          "type": "Float"
-                        }
-                      ],
-                      "hints": {}
-                    }
-                  ],
-                  "fields": [],
-                  "events": [
-                    {
-                      "name": "timer",
-                      "description": "",
-                      "type": "TimerEvent",
-                      "params": [
-                        {
-                          "name": "key",
-                          "type": "String"
-                        },
-                        {
-                          "name": "spec",
-                          "type": "String"
-                        },
-                        {
-                          "name": "maxCount",
-                          "type": "Int"
-                        }
-                      ],
-                      "hints": {}
-                    },
-                    {
-                      "name": "timerAt",
-                      "description": "",
-                      "type": "TimerEvent",
-                      "params": [
-                        {
-                          "name": "key",
-                          "type": "String"
-                        },
-                        {
-                          "name": "seconds",
-                          "type": "String"
-                        }
-                      ],
-                      "hints": {}
-                    }
-                  ]
-                },
-                {
-                  "name": "TimerEvent",
-                  "description": "",
-                  "actions": [],
-                  "fields": [
-                    {
-                      "name": "id",
-                      "description": "",
-                      "type": "String",
-                      "params": [],
-                      "hints": {}
-                    }
-                  ],
-                  "events": []
-                }
-              ],
-              "imports": []
-            },
-            "source": {
-              "Program": "tbd"
-            }
-          },
-          {
             "name": "http",
             "schema": {
               "types": [
@@ -2498,6 +2323,13 @@
                       "hints": {}
                     },
                     {
+                      "name": "auth",
+                      "description": "Transparent authentication support for API requests",
+                      "type": "Auth",
+                      "params": [],
+                      "hints": {}
+                    },
+                    {
                       "name": "gref",
                       "description": "A reference to this node",
                       "type": "Ref",
@@ -2544,35 +2376,38 @@
                     }
                   ],
                   "events": []
+                },
+                {
+                  "name": "Auth",
+                  "description": "",
+                  "actions": [
+                    {
+                      "name": "createLink",
+                      "description": "Creates a link to authenticate the user with an API and enable Membrane's Transparent Auth. Valid values for `api`: `google-docs`",
+                      "type": "String",
+                      "params": [
+                        {
+                          "name": "api",
+                          "type": "String"
+                        }
+                      ],
+                      "hints": {}
+                    }
+                  ],
+                  "fields": [
+                    {
+                      "name": "gref",
+                      "description": "A reference to this node",
+                      "type": "Ref",
+                      "ofType": "Auth",
+                      "params": [],
+                      "hints": {}
+                    }
+                  ],
+                  "events": []
                 }
               ],
               "imports": [
-                {
-                  "name": "sys-process",
-                  "schema": {
-                    "types": [
-                      {
-                        "name": "Root",
-                        "description": "",
-                        "actions": [],
-                        "fields": [
-                          {
-                            "name": "endpointUrl",
-                            "description": "Gets the program's own endpoint URL",
-                            "type": "String",
-                            "params": [],
-                            "hints": {}
-                          }
-                        ],
-                        "events": []
-                      }
-                    ],
-                    "imports": []
-                  },
-                  "source": {
-                    "Program": "tbd"
-                  }
-                },
                 {
                   "name": "sys-http",
                   "schema": {
@@ -2678,6 +2513,13 @@
                               }
                             ],
                             "hints": {}
+                          },
+                          {
+                            "name": "auth",
+                            "description": "",
+                            "type": "Auth",
+                            "params": [],
+                            "hints": {}
                           }
                         ],
                         "events": []
@@ -2709,6 +2551,26 @@
                             "hints": {}
                           }
                         ],
+                        "events": []
+                      },
+                      {
+                        "name": "Auth",
+                        "description": "",
+                        "actions": [
+                          {
+                            "name": "createLink",
+                            "description": "",
+                            "type": "String",
+                            "params": [
+                              {
+                                "name": "api",
+                                "type": "String"
+                              }
+                            ],
+                            "hints": {}
+                          }
+                        ],
+                        "fields": [],
                         "events": []
                       }
                     ],
@@ -2802,7 +2664,7 @@
                     "imports": []
                   },
                   "source": {
-                    "Program": "tbd"
+                    "Program": ""
                   }
                 },
                 {
@@ -2828,13 +2690,100 @@
                     "imports": []
                   },
                   "source": {
-                    "Program": "tbd"
+                    "Program": ""
                   }
                 }
               ]
             },
             "source": {
               "Program": "tbd"
+            }
+          },
+          {
+            "name": "sys-clock",
+            "schema": {
+              "types": [
+                {
+                  "name": "Root",
+                  "description": "",
+                  "actions": [
+                    {
+                      "name": "sleep",
+                      "description": "",
+                      "type": "Void",
+                      "params": [
+                        {
+                          "name": "key",
+                          "type": "String"
+                        },
+                        {
+                          "name": "seconds",
+                          "type": "Float"
+                        }
+                      ],
+                      "hints": {}
+                    }
+                  ],
+                  "fields": [],
+                  "events": [
+                    {
+                      "name": "timer",
+                      "description": "",
+                      "type": "TimerEvent",
+                      "params": [
+                        {
+                          "name": "key",
+                          "type": "String"
+                        },
+                        {
+                          "name": "spec",
+                          "type": "String"
+                        },
+                        {
+                          "name": "maxCount",
+                          "type": "Int"
+                        }
+                      ],
+                      "hints": {}
+                    },
+                    {
+                      "name": "timerAt",
+                      "description": "",
+                      "type": "TimerEvent",
+                      "params": [
+                        {
+                          "name": "key",
+                          "type": "String"
+                        },
+                        {
+                          "name": "seconds",
+                          "type": "String"
+                        }
+                      ],
+                      "hints": {}
+                    }
+                  ]
+                },
+                {
+                  "name": "TimerEvent",
+                  "description": "",
+                  "actions": [],
+                  "fields": [
+                    {
+                      "name": "id",
+                      "description": "",
+                      "type": "String",
+                      "params": [],
+                      "hints": {}
+                    }
+                  ],
+                  "events": []
+                }
+              ],
+              "imports": []
+            },
+            "source": {
+              "Program": ""
             }
           },
           {
@@ -2860,36 +2809,10 @@
               "imports": []
             },
             "source": {
-              "Program": "tbd"
+              "Program": ""
             }
           }
         ]
-      },
-      "source": {
-        "Program": "tbd"
-      }
-    },
-    {
-      "name": "sys-process",
-      "schema": {
-        "types": [
-          {
-            "name": "Root",
-            "description": "",
-            "actions": [],
-            "fields": [
-              {
-                "name": "endpointUrl",
-                "description": "Gets the program's own endpoint URL",
-                "type": "String",
-                "params": [],
-                "hints": {}
-              }
-            ],
-            "events": []
-          }
-        ],
-        "imports": []
       },
       "source": {
         "Program": "tbd"
@@ -2901,7 +2824,7 @@
         "types": [
           {
             "name": "Root",
-            "description": "Make HTTP requests",
+            "description": "Use this program to make HTTP requests",
             "actions": [
               {
                 "name": "post",
@@ -3009,6 +2932,23 @@
                 "hints": {}
               },
               {
+                "name": "authenticated",
+                "description": "An HTTP client that can make authenticated requests using Membrane's Transparent Authentication. Used by drivers to use avoid requiring an API key/secret pair.",
+                "type": "Authenticated",
+                "params": [
+                  {
+                    "name": "api",
+                    "type": "String"
+                  },
+                  {
+                    "name": "authId",
+                    "type": "Ref",
+                    "ofType": "String"
+                  }
+                ],
+                "hints": {}
+              },
+              {
                 "name": "gref",
                 "description": "A reference to this node",
                 "type": "Ref",
@@ -3055,35 +2995,136 @@
               }
             ],
             "events": []
+          },
+          {
+            "name": "Authenticated",
+            "description": "",
+            "actions": [
+              {
+                "name": "createLink",
+                "description": "Creates a link to authenticate the user with an API and enable Membrane's Transparent Auth. Valid values for `api`: `google-docs`",
+                "type": "String",
+                "params": [],
+                "hints": {}
+              },
+              {
+                "name": "post",
+                "description": "Performs a POST request",
+                "type": "Resource",
+                "params": [
+                  {
+                    "name": "url",
+                    "type": "String"
+                  },
+                  {
+                    "name": "headers",
+                    "type": "String"
+                  },
+                  {
+                    "name": "body",
+                    "type": "String"
+                  }
+                ],
+                "hints": {}
+              },
+              {
+                "name": "put",
+                "description": "Performs a PUT request",
+                "type": "Resource",
+                "params": [
+                  {
+                    "name": "url",
+                    "type": "String"
+                  },
+                  {
+                    "name": "headers",
+                    "type": "String"
+                  },
+                  {
+                    "name": "body",
+                    "type": "String"
+                  }
+                ],
+                "hints": {}
+              },
+              {
+                "name": "patch",
+                "description": "Performs a PATCH request",
+                "type": "Resource",
+                "params": [
+                  {
+                    "name": "url",
+                    "type": "String"
+                  },
+                  {
+                    "name": "headers",
+                    "type": "String"
+                  },
+                  {
+                    "name": "body",
+                    "type": "String"
+                  }
+                ],
+                "hints": {}
+              },
+              {
+                "name": "delete",
+                "description": "Performs a DELETE request",
+                "type": "Resource",
+                "params": [
+                  {
+                    "name": "url",
+                    "type": "String"
+                  },
+                  {
+                    "name": "headers",
+                    "type": "String"
+                  },
+                  {
+                    "name": "body",
+                    "type": "String"
+                  }
+                ],
+                "hints": {}
+              }
+            ],
+            "fields": [
+              {
+                "name": "get",
+                "description": "A resource obtained via a GET request",
+                "type": "Resource",
+                "params": [
+                  {
+                    "name": "url",
+                    "type": "String"
+                  },
+                  {
+                    "name": "headers",
+                    "type": "String"
+                  }
+                ],
+                "hints": {}
+              },
+              {
+                "name": "hasAuthenticated",
+                "description": "Whether the user has authenticated with this API",
+                "type": "Boolean",
+                "params": [],
+                "hints": {}
+              },
+              {
+                "name": "gref",
+                "description": "A reference to this node",
+                "type": "Ref",
+                "ofType": "Authenticated",
+                "params": [],
+                "hints": {}
+              }
+            ],
+            "events": []
           }
         ],
         "imports": [
-          {
-            "name": "sys-process",
-            "schema": {
-              "types": [
-                {
-                  "name": "Root",
-                  "description": "",
-                  "actions": [],
-                  "fields": [
-                    {
-                      "name": "endpointUrl",
-                      "description": "Gets the program's own endpoint URL",
-                      "type": "String",
-                      "params": [],
-                      "hints": {}
-                    }
-                  ],
-                  "events": []
-                }
-              ],
-              "imports": []
-            },
-            "source": {
-              "Program": "tbd"
-            }
-          },
           {
             "name": "sys-http",
             "schema": {
@@ -3189,6 +3230,23 @@
                         }
                       ],
                       "hints": {}
+                    },
+                    {
+                      "name": "authenticated",
+                      "description": "An HTTP client that can make authenticated requests using Membrane's Transparent Authentication. Used by drivers to use avoid requiring an API key/secret pair.",
+                      "type": "Authenticated",
+                      "params": [
+                        {
+                          "name": "api",
+                          "type": "String"
+                        },
+                        {
+                          "name": "authId",
+                          "type": "Ref",
+                          "ofType": "String"
+                        }
+                      ],
+                      "hints": {}
                     }
                   ],
                   "events": []
@@ -3216,6 +3274,125 @@
                       "name": "body",
                       "description": "",
                       "type": "String",
+                      "params": [],
+                      "hints": {}
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "name": "Authenticated",
+                  "description": "",
+                  "actions": [
+                    {
+                      "name": "createLink",
+                      "description": "Creates a link to authenticate the user with this API",
+                      "type": "String",
+                      "params": [],
+                      "hints": {}
+                    },
+                    {
+                      "name": "post",
+                      "description": "",
+                      "type": "Resource",
+                      "params": [
+                        {
+                          "name": "url",
+                          "type": "String"
+                        },
+                        {
+                          "name": "headers",
+                          "type": "String"
+                        },
+                        {
+                          "name": "body",
+                          "type": "String"
+                        }
+                      ],
+                      "hints": {}
+                    },
+                    {
+                      "name": "put",
+                      "description": "",
+                      "type": "Resource",
+                      "params": [
+                        {
+                          "name": "url",
+                          "type": "String"
+                        },
+                        {
+                          "name": "headers",
+                          "type": "String"
+                        },
+                        {
+                          "name": "body",
+                          "type": "String"
+                        }
+                      ],
+                      "hints": {}
+                    },
+                    {
+                      "name": "patch",
+                      "description": "",
+                      "type": "Resource",
+                      "params": [
+                        {
+                          "name": "url",
+                          "type": "String"
+                        },
+                        {
+                          "name": "headers",
+                          "type": "String"
+                        },
+                        {
+                          "name": "body",
+                          "type": "String"
+                        }
+                      ],
+                      "hints": {}
+                    },
+                    {
+                      "name": "delete",
+                      "description": "",
+                      "type": "Resource",
+                      "params": [
+                        {
+                          "name": "url",
+                          "type": "String"
+                        },
+                        {
+                          "name": "headers",
+                          "type": "String"
+                        },
+                        {
+                          "name": "body",
+                          "type": "String"
+                        }
+                      ],
+                      "hints": {}
+                    }
+                  ],
+                  "fields": [
+                    {
+                      "name": "get",
+                      "description": "",
+                      "type": "Resource",
+                      "params": [
+                        {
+                          "name": "url",
+                          "type": "String"
+                        },
+                        {
+                          "name": "headers",
+                          "type": "String"
+                        }
+                      ],
+                      "hints": {}
+                    },
+                    {
+                      "name": "hasAuthenticated",
+                      "description": "Whether the user has authenticated with this API",
+                      "type": "Boolean",
                       "params": [],
                       "hints": {}
                     }
@@ -3313,7 +3490,7 @@
               "imports": []
             },
             "source": {
-              "Program": "tbd"
+              "Program": ""
             }
           },
           {
@@ -3339,7 +3516,7 @@
               "imports": []
             },
             "source": {
-              "Program": "tbd"
+              "Program": ""
             }
           }
         ]


### PR DESCRIPTION
Implement a resolver for one of the `Program` fields: `pullRequests`.

This makes N requests to the Github API to find out the number of PRs for a given repo. This is generally fine but if we use the same approach for other fields, and then requests multiple fields simultaneously we're going to end up making MxN requests, which is obviously not good.


What we need is for Membrane to detect multiple queries being made to the same node and combine it together as one request.